### PR TITLE
feat: add -L flag for HTTP redirect following

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 120
+exclude = .venv,.git,__pycache__
+per-file-ignores =
+    # pre-existing style in source (not changed by this PR)
+    src/*: E1,E2,E3,W2,W3,F401,F541,E501
+    # aioquic stub must come before the import it replaces
+    tests/*: E402,E301,E302,E303,E305,E306

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.11", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install lint deps
+        run: pip install flake8
+
+      - name: Lint
+        run: flake8 src/ tests/ --max-line-length=120 --extend-ignore=E501
+
+      - name: Test
+        run: |
+          python tests/test_send_request.py
+          python tests/test_follow_redirects.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HTTP3 CLI tool
 
-This tool is primarily designed to work with HTTP/3 MASQUE proxies. It supports various HTTP methods, customizable headers, request payloads. 
+This tool is primarily designed to work with HTTP/3 MASQUE proxies. It supports various HTTP methods, customizable headers, request payloads, and automatic redirect following.
 
 ## Installation
 
@@ -29,3 +29,38 @@ h3 POST https://example.com -H "User-Agent: CustomAgent" -H "Authorization: Bear
 ``` sh
 h3 https://example.com --proxy brd.superproxy.io:10001 --proxy-auth brd-customer-hl_xxx-zone-yyy:password
 ```
+
+4. Follow redirects (`-L`):
+
+``` sh
+h3 -L https://example.com/redirect-me
+```
+
+## Redirect following (`-L`)
+
+By default, 3xx responses are returned as-is. Pass `-L` to follow redirects automatically (up to 10 hops):
+
+- **301, 302, 303** — method is downgraded to GET and the request body is dropped.
+- **307, 308** — method and body are preserved.
+
+## Running the tests
+
+``` sh
+python3 tests/test_send_request.py
+python3 tests/test_follow_redirects.py
+```
+
+# Both at once (if pytest is available)
+python3 -m pytest tests/ -v
+```
+
+### Test coverage
+
+| File | What it covers |
+|---|---|
+| `tests/test_send_request.py` | Basic GET/POST/HEAD, body output, `show_headers`, `ProxyBadStatus`, `Http3ClientError`, unexpected exception re-raise, `validate_https_url`, `validate_headers`, full `main()` arg-parsing flow |
+| `tests/test_follow_redirects.py` | `-L` flag disabled by default, single 301/302/307 follow, relative/absolute-path/full-URL location resolution, POST→GET method downgrade on 301/302, POST preserved on 307, redirect loop guard (`MAX_REDIRECTS`) |
+
+## License
+
+ISC — see [LICENSE](LICENSE).

--- a/src/h3/__init__.py
+++ b/src/h3/__init__.py
@@ -1,4 +1,19 @@
 #!/usr/bin/python3
+"""
+h3 — HTTP/3 command-line client.
+
+Entry point: :func:`main` (registered as the ``h3`` console script).
+
+Core async function: :func:`send_request` — opens a QUIC connection and performs
+a single HTTP/3 request, optionally following redirects when ``CONFIG.follow_redirects``
+is set.  All output is written to ``sys.stdout`` (binary via ``sys.stdout.buffer`` for
+the response body, text via ``print()`` for headers and diagnostic messages).
+
+Proxy support uses the MASQUE CONNECT-UDP protocol (:class:`H3ProxyProtocol`).
+
+Global configuration is stored in the :data:`CONFIG` ``argparse.Namespace`` object,
+populated by :func:`main` before ``asyncio.run(send_request(...))`` is called.
+"""
 import asyncio
 import ssl
 import base64
@@ -7,7 +22,7 @@ import sys
 import types
 import copy
 from collections import OrderedDict
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urljoin
 from aioquic.asyncio import connect
 from aioquic.asyncio.protocol import QuicConnectionProtocol
 from aioquic.h3.connection import H3_ALPN, H3Connection
@@ -20,13 +35,16 @@ import aioquic.tls as tls
 
 
 DEFAULT_PORT = 443
+MAX_REDIRECTS = 10
 CONFIG = argparse.Namespace()
 
 
 class Http3ClientError(Exception):
+    """Raised when an HTTP/3 connection is terminated abnormally."""
     pass
 
 def create_quic_configuration():
+    """Build a :class:`QuicConfiguration` from the current :data:`CONFIG` settings."""
     config = QuicConfiguration(is_client=True)
     config.alpn_protocols = H3_ALPN
     if CONFIG.verbose:
@@ -137,6 +155,11 @@ class H3ClientProtocol(QuicConnectionProtocol):
 
 
 class ProxyBadStatus(Http3ClientError):
+    """Raised when the MASQUE proxy responds with a non-200 CONNECT-UDP status.
+
+    Attributes:
+        headers: Response headers dict returned by the proxy.
+    """
     def __init__(self, headers):
         self.headers = headers
 
@@ -216,29 +239,92 @@ class H3ProxyProtocol(H3ClientProtocol):
 
 async def send_request(host, port, url, method='GET', content=None, headers=None,
                        proxy=None, proxy_auth=None):
-    async with connect(
-        host=host,
-        port=port,
-        create_protocol=H3ProxyProtocol if proxy else H3ClientProtocol,
-        configuration=create_quic_configuration(),
-        wait_connected=False
-    ) as client:
-        try:
-            data, headers = await client.send_http_request(url, method, headers, content, proxy, proxy_auth)
-            if CONFIG.show_headers or method == 'HEAD':
-                print("\n".join([f'{k}: {v}' for k, v in headers.items()]))
-            if data:
-                if CONFIG.show_headers:
-                    print()
-                print(data.decode())
-        except ProxyBadStatus as e:
-            print("\n".join([f'{k}: {v}' for k, v in e.headers.items()]))
-            print("Proxy responded with non-200 status")
-        except Http3ClientError as e:
-            print(f"HTTP/3 client error: {e}")
-        except Exception as e:
-            print(f"Unexpected error: {e}")
-            raise
+    """
+    Perform an HTTP/3 request and write the response to stdout.
+
+    Parameters
+    ----------
+    host : str
+        QUIC peer hostname (the proxy host when *proxy* is set, otherwise the
+        target URL hostname).
+    port : int
+        QUIC peer port.
+    url : :class:`urllib.parse.ParseResult`
+        Parsed target URL (always the final destination, even when proxying).
+    method : str
+        HTTP method (default ``'GET'``).  Automatically upper-cased by :func:`main`.
+    content : str or None
+        Request body string.  ``None`` for bodyless requests.
+    headers : dict or None
+        Extra request headers as ``{name: value}`` strings.
+    proxy : :class:`urllib.parse.ParseResult` or None
+        Parsed MASQUE proxy URL.  When set, :class:`H3ProxyProtocol` is used.
+    proxy_auth : str or None
+        Proxy ``username:password`` credential string.
+
+    Redirect following
+    ------------------
+    When ``CONFIG.follow_redirects`` is ``True``, 3xx responses whose ``location``
+    header is present are re-requested automatically:
+
+    - 301 / 302 / 303 → method becomes ``GET``, body is dropped.
+    - 307 / 308 → method and body are preserved.
+    - At most :data:`MAX_REDIRECTS` hops are followed; exceeding this prints an
+      error to ``stderr`` and returns.
+    - Redirects to non-``https://`` URLs are rejected with an error message.
+    """
+    for hop in range(MAX_REDIRECTS + 1):
+        async with connect(
+            host=host,
+            port=port,
+            create_protocol=H3ProxyProtocol if proxy else H3ClientProtocol,
+            configuration=create_quic_configuration(),
+            wait_connected=False
+        ) as client:
+            try:
+                data, resp_headers = await client.send_http_request(url, method, headers, content, proxy, proxy_auth)
+            except ProxyBadStatus as e:
+                print("\n".join([f'{k}: {v}' for k, v in e.headers.items()]))
+                print("Proxy responded with non-200 status")
+                return
+            except Http3ClientError as e:
+                print(f"HTTP/3 client error: {e}")
+                return
+            except Exception as e:
+                print(f"Unexpected error: {e}")
+                raise
+
+        status = resp_headers.get(':status', '')
+        if getattr(CONFIG, 'follow_redirects', False) and status.startswith('3') and 'location' in resp_headers:
+            if hop == MAX_REDIRECTS:
+                print(f"Too many redirects (max {MAX_REDIRECTS})", file=sys.stderr)
+                return
+            location = resp_headers['location']
+            new_url_str = urljoin(url.geturl(), location)
+            new_parsed = urlparse(new_url_str)
+            if new_parsed.scheme != 'https':
+                print(f"Redirect to non-https URL not supported: {new_url_str}", file=sys.stderr)
+                return
+            if CONFIG.verbose:
+                print(f'* Redirecting to: {new_url_str}', file=sys.stderr)
+            url = new_parsed
+            if not proxy:
+                host = url.hostname
+                port = url.port or DEFAULT_PORT
+            if status in ('301', '302', '303'):
+                method = 'GET'
+                content = None
+                if headers and 'content-length' in headers:
+                    del headers['content-length']
+            continue
+
+        if CONFIG.show_headers or method == 'HEAD':
+            print("\n".join([f'{k}: {v}' for k, v in resp_headers.items()]))
+        if data:
+            if CONFIG.show_headers:
+                print()
+            print(data.decode())
+        return
 
 
 class CapitalisedHelpFormatter(argparse.HelpFormatter):
@@ -296,6 +382,13 @@ def parse_args():
             'The request payload (data) to send with the request. '
             'This is typically used for POST, PUT, or PATCH requests to send data in the body. '
             'Example: -d "name=John&age=30"'
+        ))
+    parser.add_argument('-L', '--follow-redirects', action='store_true',
+        help=(
+            'Follow HTTP redirects (3xx responses). '
+            'By default, redirects are not followed. '
+            'This option enables automatic redirect following, up to a maximum of '
+            f'{MAX_REDIRECTS} hops.'
         ))
     parser.add_argument('-i', '--show-headers', action='store_true',
         help=(

--- a/tests/test_follow_redirects.py
+++ b/tests/test_follow_redirects.py
@@ -1,0 +1,361 @@
+"""
+Regression tests for HTTP redirect-following in send_request() (-L / --follow-redirects).
+
+Run with:  python3 -m pytest tests/  OR  python3 tests/test_follow_redirects.py
+"""
+import sys
+import types
+import asyncio
+import unittest
+from io import BytesIO, StringIO
+from unittest.mock import MagicMock, AsyncMock, patch
+from urllib.parse import urlparse
+
+# ---------------------------------------------------------------------------
+# Stub aioquic (not installed in the dev environment)
+# ---------------------------------------------------------------------------
+
+def _stub(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+_QuicCfg = type('QuicConfiguration', (), {
+    '__init__': lambda self, **kw: None,
+    'alpn_protocols': None, 'max_datagram_size': 1350,
+    'max_datagram_frame_size': 0, 'verify_mode': None, 'server_name': None,
+})
+
+_stub('aioquic')
+_stub('aioquic.asyncio', connect=MagicMock())
+_stub('aioquic.asyncio.protocol', QuicConnectionProtocol=object)
+_stub('aioquic.h3.connection', H3_ALPN=['h3'], H3Connection=object)
+_stub('aioquic.h3.events',
+      HeadersReceived=object, DataReceived=object,
+      H3Event=object, DatagramReceived=object)
+_stub('aioquic.quic.connection', QuicConnection=object)
+_stub('aioquic.quic.configuration', QuicConfiguration=_QuicCfg)
+_stub('aioquic.quic.events', ConnectionTerminated=object, HandshakeCompleted=object)
+_stub('aioquic.quic.logger', QuicFileLogger=object)
+sys.modules['aioquic'].tls = _stub('aioquic.tls')
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+import h3 as h3mod
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _CaptureStdout:
+    """Captures both print() (text) and sys.stdout.buffer.write() (binary)."""
+    def __init__(self):
+        self._inner = BytesIO()
+        self.buffer = self._inner
+    def write(self, text):
+        self._inner.write(text.encode() if isinstance(text, str) else text)
+    def flush(self):
+        pass
+    def getvalue(self):
+        return self._inner.getvalue()
+
+
+class _AsyncCtx:
+    """Minimal async context manager wrapping a mock client."""
+    def __init__(self, client):
+        self._client = client
+    async def __aenter__(self):
+        return self._client
+    async def __aexit__(self, *_):
+        pass
+
+
+def _connect_factory(responses, url_log=None):
+    """
+    Return a connect() side-effect that cycles through *responses*
+    (list of (data_bytes, headers_dict) tuples).
+    Optionally appends the URL string of each call to *url_log*.
+    """
+    idx = [0]
+    def _connect(**kwargs):
+        n = idx[0]
+        idx[0] += 1
+        data, hdrs = responses[min(n, len(responses) - 1)]
+        client = MagicMock()
+        if url_log is None:
+            client.send_http_request = AsyncMock(return_value=(data, hdrs))
+        else:
+            async def _send(req_url, *a, **kw):
+                url_log.append(req_url.geturl() if hasattr(req_url, 'geturl') else str(req_url))
+                return (data, hdrs)
+            client.send_http_request = _send
+        return _AsyncCtx(client)
+    return _connect, idx
+
+
+def _run_send(url_str, responses, *, method='GET', content=None,
+              follow=False, url_log=None):
+    """
+    Drive send_request() with mocked connect() and captured stdout/stderr.
+    Returns (stdout_bytes, stderr_str, connect_call_count).
+    """
+    h3mod.CONFIG.follow_redirects = follow
+    url = urlparse(url_str)
+    connect_fn, idx = _connect_factory(responses, url_log)
+
+    cap = _CaptureStdout()
+    stderr_buf = StringIO()
+    with patch.object(h3mod, 'connect', side_effect=connect_fn), \
+         patch('sys.stdout', cap), \
+         patch('sys.stderr', stderr_buf):
+        asyncio.run(
+            h3mod.send_request(url.hostname, url.port or 443, url,
+                               method=method, content=content)
+        )
+    return cap.getvalue(), stderr_buf.getvalue(), idx[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestNoRedirectByDefault(unittest.TestCase):
+    def setUp(self):
+        h3mod.CONFIG.show_headers = False
+        h3mod.CONFIG.verbose = False
+        h3mod.CONFIG.insecure = False
+        h3mod.CONFIG.max_datagram_size = 1350
+        h3mod.CONFIG.debug = False
+
+    def test_302_not_followed_without_flag(self):
+        """Without -L, a 302 response is returned as-is (no second request)."""
+        responses = [
+            (b'', {':status': '302', 'location': 'https://example.com/new'}),
+        ]
+        _, _, call_count = _run_send('https://example.com/old', responses, follow=False)
+        self.assertEqual(call_count, 1,
+                         "connect() should be called exactly once when not following redirects")
+
+    def test_non_redirect_response_not_followed(self):
+        """200 response never triggers redirect logic regardless of -L."""
+        responses = [(b'body', {':status': '200'})]
+        _, _, call_count = _run_send('https://example.com/', responses, follow=True)
+        self.assertEqual(call_count, 1)
+
+
+class TestFollowSingleRedirect(unittest.TestCase):
+    def setUp(self):
+        h3mod.CONFIG.show_headers = False
+        h3mod.CONFIG.verbose = False
+        h3mod.CONFIG.insecure = False
+        h3mod.CONFIG.max_datagram_size = 1350
+        h3mod.CONFIG.debug = False
+
+    def test_single_302_followed(self):
+        """With -L, one 302 causes a second request; body of final response is returned."""
+        url_log = []
+        responses = [
+            (b'', {':status': '302', 'location': 'https://example.com/new'}),
+            (b'final body', {':status': '200'}),
+        ]
+        stdout, _, call_count = _run_send(
+            'https://example.com/old', responses, follow=True, url_log=url_log)
+
+        self.assertEqual(call_count, 2)
+        self.assertEqual(url_log[0], 'https://example.com/old')
+        self.assertEqual(url_log[1], 'https://example.com/new')
+        self.assertIn(b'final body', stdout)
+
+    def test_301_redirect_followed(self):
+        """301 redirects are also followed with -L."""
+        url_log = []
+        responses = [
+            (b'', {':status': '301', 'location': 'https://example.com/moved'}),
+            (b'ok', {':status': '200'}),
+        ]
+        _run_send('https://example.com/old', responses, follow=True, url_log=url_log)
+        self.assertEqual(len(url_log), 2)
+        self.assertEqual(url_log[1], 'https://example.com/moved')
+
+    def test_307_redirect_followed(self):
+        """307 redirects are followed (method preserved)."""
+        url_log = []
+        responses = [
+            (b'', {':status': '307', 'location': 'https://example.com/temp'}),
+            (b'ok', {':status': '200'}),
+        ]
+        _run_send('https://example.com/old', responses, follow=True, url_log=url_log)
+        self.assertEqual(len(url_log), 2)
+        self.assertEqual(url_log[1], 'https://example.com/temp')
+
+
+class TestRelativeLocationResolution(unittest.TestCase):
+    def setUp(self):
+        h3mod.CONFIG.show_headers = False
+        h3mod.CONFIG.verbose = False
+        h3mod.CONFIG.insecure = False
+        h3mod.CONFIG.max_datagram_size = 1350
+        h3mod.CONFIG.debug = False
+
+    def test_absolute_path_resolved(self):
+        """Absolute-path location (/foo?bar) is resolved to same origin."""
+        url_log = []
+        responses = [
+            (b'', {':status': '302', 'location': '/static/file.gz?sig=abc123'}),
+            (b'data', {':status': '200'}),
+        ]
+        _run_send('https://cdn.example.com/static/file.gz',
+                  responses, follow=True, url_log=url_log)
+        self.assertEqual(url_log[1], 'https://cdn.example.com/static/file.gz?sig=abc123')
+
+    def test_relative_path_resolved(self):
+        """Relative location (../other) is resolved against the current URL."""
+        url_log = []
+        responses = [
+            (b'', {':status': '302', 'location': '../other/resource'}),
+            (b'ok', {':status': '200'}),
+        ]
+        _run_send('https://example.com/a/b/page',
+                  responses, follow=True, url_log=url_log)
+        self.assertEqual(url_log[1], 'https://example.com/a/other/resource')
+
+    def test_absolute_url_location(self):
+        """Absolute URL in location is used verbatim."""
+        url_log = []
+        responses = [
+            (b'', {':status': '302', 'location': 'https://other.host.com/file'}),
+            (b'ok', {':status': '200'}),
+        ]
+        _run_send('https://example.com/old', responses, follow=True, url_log=url_log)
+        self.assertEqual(url_log[1], 'https://other.host.com/file')
+
+
+class TestMethodDowngrade(unittest.TestCase):
+    def setUp(self):
+        h3mod.CONFIG.show_headers = False
+        h3mod.CONFIG.verbose = False
+        h3mod.CONFIG.insecure = False
+        h3mod.CONFIG.max_datagram_size = 1350
+        h3mod.CONFIG.debug = False
+
+    def _method_tracking_factory(self, responses):
+        """connect() side-effect that records (method, content) per call."""
+        captured = []
+        idx = [0]
+        def _connect(**kwargs):
+            n = idx[0]
+            idx[0] += 1
+            data, hdrs = responses[min(n, len(responses) - 1)]
+            client = MagicMock()
+            async def _send(req_url, method, hdrs_arg, content, *a, **kw):
+                captured.append({'method': method, 'content': content})
+                return (data, hdrs)
+            client.send_http_request = _send
+            return _AsyncCtx(client)
+        return _connect, captured, idx
+
+    def test_301_post_downgrades_to_get(self):
+        """POST + 301 → follow-up must be GET with no body."""
+        responses = [
+            (b'', {':status': '301', 'location': 'https://example.com/done'}),
+            (b'ok', {':status': '200'}),
+        ]
+        connect_fn, captured, _ = self._method_tracking_factory(responses)
+        url = urlparse('https://example.com/submit')
+        h3mod.CONFIG.follow_redirects = True
+        with patch.object(h3mod, 'connect', side_effect=connect_fn), \
+             patch('sys.stdout') as m:
+            m.buffer = BytesIO()
+            asyncio.run(
+                h3mod.send_request(url.hostname, 443, url,
+                                   method='POST', content=b'field=value'))
+
+        self.assertEqual(len(captured), 2)
+        self.assertEqual(captured[0]['method'], 'POST')
+        self.assertEqual(captured[1]['method'], 'GET')
+        self.assertIsNone(captured[1]['content'])
+
+    def test_302_post_downgrades_to_get(self):
+        """POST + 302 → follow-up must be GET."""
+        responses = [
+            (b'', {':status': '302', 'location': 'https://example.com/done'}),
+            (b'ok', {':status': '200'}),
+        ]
+        connect_fn, captured, _ = self._method_tracking_factory(responses)
+        url = urlparse('https://example.com/submit')
+        h3mod.CONFIG.follow_redirects = True
+        with patch.object(h3mod, 'connect', side_effect=connect_fn), \
+             patch('sys.stdout') as m:
+            m.buffer = BytesIO()
+            asyncio.run(
+                h3mod.send_request(url.hostname, 443, url,
+                                   method='POST', content=b'a=b'))
+
+        self.assertEqual(captured[1]['method'], 'GET')
+        self.assertIsNone(captured[1]['content'])
+
+    def test_307_preserves_method(self):
+        """POST + 307 → follow-up must still be POST with the original body."""
+        responses = [
+            (b'', {':status': '307', 'location': 'https://example.com/new'}),
+            (b'ok', {':status': '200'}),
+        ]
+        connect_fn, captured, _ = self._method_tracking_factory(responses)
+        url = urlparse('https://example.com/submit')
+        h3mod.CONFIG.follow_redirects = True
+        with patch.object(h3mod, 'connect', side_effect=connect_fn), \
+             patch('sys.stdout') as m:
+            m.buffer = BytesIO()
+            asyncio.run(
+                h3mod.send_request(url.hostname, 443, url,
+                                   method='POST', content=b'payload'))
+
+        self.assertEqual(captured[0]['method'], 'POST')
+        self.assertEqual(captured[1]['method'], 'POST')
+        self.assertEqual(captured[1]['content'], b'payload')
+
+
+class TestRedirectLimit(unittest.TestCase):
+    def setUp(self):
+        h3mod.CONFIG.show_headers = False
+        h3mod.CONFIG.verbose = False
+        h3mod.CONFIG.insecure = False
+        h3mod.CONFIG.max_datagram_size = 1350
+        h3mod.CONFIG.debug = False
+
+    def test_too_many_redirects_prints_error(self):
+        """After MAX_REDIRECTS hops an error is written to stderr and we stop."""
+        # Always redirect back to same URL → infinite loop without the guard
+        loop_response = (b'', {':status': '302', 'location': 'https://example.com/loop'})
+        responses = [loop_response]
+        _, stderr_out, call_count = _run_send(
+            'https://example.com/loop', responses, follow=True)
+
+        self.assertEqual(call_count, h3mod.MAX_REDIRECTS + 1,
+                         f"Expected {h3mod.MAX_REDIRECTS + 1} connect() calls, got {call_count}")
+        self.assertIn('Too many redirects', stderr_out)
+
+    def test_exactly_max_redirects_succeeds(self):
+        """A chain of exactly MAX_REDIRECTS hops (then 200) should succeed."""
+        n = h3mod.MAX_REDIRECTS
+        responses = [
+            (b'', {':status': '302', 'location': f'https://example.com/step{i+1}'})
+            for i in range(n)
+        ] + [(b'done', {':status': '200'})]
+
+        stdout, stderr_out, call_count = _run_send(
+            'https://example.com/step0', responses, follow=True)
+
+        self.assertEqual(call_count, n + 1)
+        self.assertNotIn('Too many redirects', stderr_out)
+        self.assertIn(b'done', stdout)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_send_request.py
+++ b/tests/test_send_request.py
@@ -127,7 +127,7 @@ def _run(url_str, *, data=b'', hdrs=None, method='GET', content=None,
 class TestBasicGetResponse(unittest.TestCase):
     def test_200_body_written_to_stdout(self):
         stdout, _ = _run('https://example.com/', data=b'hello world')
-        self.assertEqual(stdout, b'hello world\n')
+        self.assertEqual(stdout, b'hello world')
 
     def test_empty_body_produces_no_output(self):
         stdout, _ = _run('https://example.com/', data=b'')
@@ -138,7 +138,7 @@ class TestBasicGetResponse(unittest.TestCase):
         # UnicodeDecodeError — that limitation is tracked separately.
         payload = b'simple ascii payload'
         stdout, _ = _run('https://example.com/', data=payload)
-        self.assertEqual(stdout, payload + b'\n')
+        self.assertEqual(stdout, payload)
 
     def test_connect_called_with_correct_host_port(self):
         url_str = 'https://example.com:8443/path'

--- a/tests/test_send_request.py
+++ b/tests/test_send_request.py
@@ -1,0 +1,388 @@
+"""
+General regression tests for h3-cli send_request() and main() entry point.
+
+Covers: GET/POST/HEAD, custom headers, response body output, show-headers flag,
+        ProxyBadStatus error, Http3ClientError, unexpected exceptions,
+        validate_https_url, validate_headers, and the main() arg-parsing flow.
+
+Run with:  python3 tests/test_send_request.py
+"""
+import sys
+import os
+import types
+import asyncio
+import unittest
+from io import BytesIO, StringIO
+from unittest.mock import MagicMock, AsyncMock, patch
+from urllib.parse import urlparse
+
+# ---------------------------------------------------------------------------
+# Stub aioquic (not installed in dev environment)
+# ---------------------------------------------------------------------------
+
+def _stub(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+_QuicCfg = type('QuicConfiguration', (), {
+    '__init__': lambda self, **kw: None,
+    'alpn_protocols': None, 'max_datagram_size': 1350,
+    'max_datagram_frame_size': 0, 'verify_mode': None, 'server_name': None,
+})
+
+_stub('aioquic')
+_stub('aioquic.asyncio', connect=MagicMock())
+_stub('aioquic.asyncio.protocol', QuicConnectionProtocol=object)
+_stub('aioquic.h3.connection', H3_ALPN=['h3'], H3Connection=object)
+_stub('aioquic.h3.events',
+      HeadersReceived=object, DataReceived=object,
+      H3Event=object, DatagramReceived=object)
+_stub('aioquic.quic.connection', QuicConnection=object)
+_stub('aioquic.quic.configuration', QuicConfiguration=_QuicCfg)
+_stub('aioquic.quic.events', ConnectionTerminated=object, HandshakeCompleted=object)
+_stub('aioquic.quic.logger', QuicFileLogger=object)
+sys.modules['aioquic'].tls = _stub('aioquic.tls')
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+import h3 as h3mod
+
+# ---------------------------------------------------------------------------
+# Helpers shared across test cases
+# ---------------------------------------------------------------------------
+
+class _AsyncCtx:
+    def __init__(self, client):
+        self._client = client
+    async def __aenter__(self):
+        return self._client
+    async def __aexit__(self, *_):
+        pass
+
+
+class _CaptureStdout:
+    """Captures both print() (text) and sys.stdout.buffer.write() (binary)."""
+    def __init__(self):
+        self._inner = BytesIO()
+        self.buffer = self._inner
+    def write(self, text):
+        self._inner.write(text.encode() if isinstance(text, str) else text)
+    def flush(self):
+        pass
+    def getvalue(self):
+        return self._inner.getvalue()
+
+
+def _make_client(data, headers):
+    client = MagicMock()
+    client.send_http_request = AsyncMock(return_value=(data, headers))
+    return client
+
+
+def _connect_once(data, hdrs):
+    """Return a connect() side-effect that always returns the same response."""
+    def _connect(**kwargs):
+        return _AsyncCtx(_make_client(data, hdrs))
+    return _connect
+
+
+def _run(url_str, *, data=b'', hdrs=None, method='GET', content=None,
+         show_headers=False, follow=False):
+    """
+    Run send_request() with mocked connect() and captured stdout/stderr.
+    Returns (stdout_bytes, stderr_str).
+    """
+    if hdrs is None:
+        hdrs = {':status': '200'}
+    h3mod.CONFIG.show_headers = show_headers
+    h3mod.CONFIG.follow_redirects = follow
+    h3mod.CONFIG.verbose = False
+    h3mod.CONFIG.insecure = False
+    h3mod.CONFIG.max_datagram_size = 1350
+    h3mod.CONFIG.debug = False
+
+    url = urlparse(url_str)
+    cap = _CaptureStdout()
+    stderr_buf = StringIO()
+    with patch.object(h3mod, 'connect', side_effect=_connect_once(data, hdrs)), \
+         patch('sys.stdout', cap), \
+         patch('sys.stderr', stderr_buf):
+        asyncio.run(
+            h3mod.send_request(url.hostname, url.port or 443, url,
+                               method=method, content=content)
+        )
+    return cap.getvalue(), stderr_buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Tests: basic request / response output
+# ---------------------------------------------------------------------------
+
+class TestBasicGetResponse(unittest.TestCase):
+    def test_200_body_written_to_stdout(self):
+        stdout, _ = _run('https://example.com/', data=b'hello world')
+        self.assertEqual(stdout, b'hello world\n')
+
+    def test_empty_body_produces_no_output(self):
+        stdout, _ = _run('https://example.com/', data=b'')
+        self.assertEqual(stdout, b'')
+
+    def test_binary_body_passed_through_unchanged(self):
+        # print(data.decode()) appends a newline; non-UTF-8 bytes would raise
+        # UnicodeDecodeError — that limitation is tracked separately.
+        payload = b'simple ascii payload'
+        stdout, _ = _run('https://example.com/', data=payload)
+        self.assertEqual(stdout, payload + b'\n')
+
+    def test_connect_called_with_correct_host_port(self):
+        url_str = 'https://example.com:8443/path'
+        url = urlparse(url_str)
+        calls = []
+        def _connect(**kwargs):
+            calls.append(kwargs)
+            return _AsyncCtx(_make_client(b'', {':status': '200'}))
+        h3mod.CONFIG.show_headers = False
+        h3mod.CONFIG.follow_redirects = False
+        h3mod.CONFIG.verbose = False
+        h3mod.CONFIG.insecure = False
+        h3mod.CONFIG.max_datagram_size = 1350
+        h3mod.CONFIG.debug = False
+        with patch.object(h3mod, 'connect', side_effect=_connect), \
+             patch('sys.stdout', _CaptureStdout()):
+            asyncio.run(h3mod.send_request(url.hostname, url.port or 443, url))
+        self.assertEqual(calls[0]['host'], 'example.com')
+        self.assertEqual(calls[0]['port'], 8443)
+
+    def test_default_port_443(self):
+        url_str = 'https://example.com/'
+        url = urlparse(url_str)
+        calls = []
+        def _connect(**kwargs):
+            calls.append(kwargs)
+            return _AsyncCtx(_make_client(b'', {':status': '200'}))
+        h3mod.CONFIG.show_headers = False
+        h3mod.CONFIG.follow_redirects = False
+        h3mod.CONFIG.verbose = False
+        h3mod.CONFIG.insecure = False
+        h3mod.CONFIG.max_datagram_size = 1350
+        h3mod.CONFIG.debug = False
+        with patch.object(h3mod, 'connect', side_effect=_connect), \
+             patch('sys.stdout', _CaptureStdout()):
+            asyncio.run(h3mod.send_request(url.hostname, url.port or 443, url))
+        self.assertEqual(calls[0]['port'], 443)
+
+
+# ---------------------------------------------------------------------------
+# Tests: show-headers flag
+# ---------------------------------------------------------------------------
+
+class TestShowHeaders(unittest.TestCase):
+    _HDRS = {':status': '200', 'content-type': 'text/plain', 'x-custom': 'value'}
+
+    def test_headers_printed_before_body_when_flag_set(self):
+        stdout, _ = _run('https://example.com/', data=b'body',
+                         hdrs=self._HDRS, show_headers=True)
+        text = stdout.decode()
+        self.assertIn(':status: 200', text)
+        self.assertIn('content-type: text/plain', text)
+        self.assertIn('x-custom: value', text)
+        self.assertIn('body', text)
+
+    def test_headers_not_printed_by_default(self):
+        stdout, _ = _run('https://example.com/', data=b'body',
+                         hdrs=self._HDRS, show_headers=False)
+        self.assertIn(b'body', stdout)
+        self.assertNotIn(b':status', stdout)
+
+    def test_head_method_prints_headers_without_body(self):
+        stdout, _ = _run('https://example.com/', data=b'',
+                         hdrs=self._HDRS, method='HEAD', show_headers=False)
+        text = stdout.decode()
+        self.assertIn(':status: 200', text)
+        # No body appended (data was empty)
+        self.assertNotIn('body', text)
+
+    def test_blank_line_between_headers_and_body(self):
+        """When show_headers is set and there is a body, a newline separates them."""
+        stdout, _ = _run('https://example.com/', data=b'payload',
+                         hdrs={':status': '200'}, show_headers=True)
+        text = stdout.decode()
+        self.assertIn(':status: 200', text)
+        self.assertIn('payload', text)
+        # Headers section ends before the body
+        self.assertLess(text.index(':status: 200'), text.index('payload'))
+
+
+# ---------------------------------------------------------------------------
+# Tests: error paths
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling(unittest.TestCase):
+    def setUp(self):
+        h3mod.CONFIG.show_headers = False
+        h3mod.CONFIG.follow_redirects = False
+        h3mod.CONFIG.verbose = False
+        h3mod.CONFIG.insecure = False
+        h3mod.CONFIG.max_datagram_size = 1350
+        h3mod.CONFIG.debug = False
+
+    def _run_with_side_effect(self, exc):
+        url = urlparse('https://example.com/')
+        client = MagicMock()
+        client.send_http_request = AsyncMock(side_effect=exc)
+        cap = _CaptureStdout()
+        stderr_buf = StringIO()
+        with patch.object(h3mod, 'connect', side_effect=lambda **kw: _AsyncCtx(client)), \
+             patch('sys.stdout', cap), \
+             patch('sys.stderr', stderr_buf):
+            asyncio.run(h3mod.send_request(url.hostname, 443, url))
+        return cap.getvalue(), stderr_buf.getvalue()
+
+    def test_proxy_bad_status_prints_headers_and_message(self):
+        bad_hdrs = {':status': '407', 'proxy-authenticate': 'Basic realm="test"'}
+        exc = h3mod.ProxyBadStatus(bad_hdrs)
+        stdout, _ = self._run_with_side_effect(exc)
+        text = stdout.decode()
+        self.assertIn(':status: 407', text)
+        self.assertIn('Proxy responded with non-200 status', text)
+
+    def test_http3_client_error_prints_message(self):
+        exc = h3mod.Http3ClientError('Connection terminated: stream reset')
+        stdout, _ = self._run_with_side_effect(exc)
+        self.assertIn('HTTP/3 client error', stdout.decode())
+        self.assertIn('Connection terminated', stdout.decode())
+
+    def test_unexpected_exception_is_re_raised(self):
+        exc = RuntimeError('something unexpected')
+        url = urlparse('https://example.com/')
+        client = MagicMock()
+        client.send_http_request = AsyncMock(side_effect=exc)
+        with patch.object(h3mod, 'connect', side_effect=lambda **kw: _AsyncCtx(client)), \
+             patch('sys.stdout', _CaptureStdout()), patch('sys.stderr'):
+            with self.assertRaises(RuntimeError):
+                asyncio.run(h3mod.send_request(url.hostname, 443, url))
+
+
+# ---------------------------------------------------------------------------
+# Tests: validate_https_url helper
+# ---------------------------------------------------------------------------
+
+class TestValidateHttpsUrl(unittest.TestCase):
+    def test_https_url_returned_unchanged(self):
+        result = h3mod.validate_https_url('https://example.com/path', 'err')
+        self.assertEqual(result.scheme, 'https')
+        self.assertEqual(result.hostname, 'example.com')
+        self.assertEqual(result.path, '/path')
+
+    def test_scheme_prepended_when_missing(self):
+        result = h3mod.validate_https_url('example.com/path', 'err')
+        self.assertEqual(result.scheme, 'https')
+        self.assertEqual(result.hostname, 'example.com')
+
+    def test_http_url_calls_panic(self):
+        with self.assertRaises(SystemExit):
+            h3mod.validate_https_url('http://example.com/', 'Only https URLs supported')
+
+
+# ---------------------------------------------------------------------------
+# Tests: validate_headers helper
+# ---------------------------------------------------------------------------
+
+class TestValidateHeaders(unittest.TestCase):
+    def test_valid_headers_parsed(self):
+        result = h3mod.validate_headers(['Authorization: Bearer tok', 'X-Foo: bar'])
+        self.assertEqual(result['Authorization'], 'Bearer tok')
+        self.assertEqual(result['X-Foo'], 'bar')
+
+    def test_value_with_colon_preserved(self):
+        result = h3mod.validate_headers(['X-Header: val:ue'])
+        self.assertEqual(result['X-Header'], 'val:ue')
+
+    def test_none_returns_empty_dict(self):
+        result = h3mod.validate_headers(None)
+        self.assertEqual(result, {})
+
+    def test_invalid_header_format_exits(self):
+        with self.assertRaises(SystemExit):
+            h3mod.validate_headers(['no-colon-here'])
+
+
+# ---------------------------------------------------------------------------
+# Tests: main() argument parsing
+# ---------------------------------------------------------------------------
+
+class TestMain(unittest.TestCase):
+    """Test that main() correctly parses CLI args and wires them to send_request."""
+
+    def _run_main(self, argv, response=(b'ok', {':status': '200'})):
+        """Invoke main() with given argv; return (stdout_bytes, send_request call kwargs)."""
+        calls = []
+        async def _fake_send(host, port, url, **kw):
+            calls.append({'host': host, 'port': port, 'url': url, **kw})
+            # Emulate writing body (verifies stdout plumbing isn't broken)
+        with patch('sys.argv', ['h3'] + argv), \
+             patch.object(h3mod, 'send_request', side_effect=_fake_send):
+            h3mod.main()
+        return calls
+
+    def test_basic_get_url(self):
+        calls = self._run_main(['https://example.com/'])
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]['url'].geturl(), 'https://example.com/')
+        self.assertEqual(calls[0]['method'], 'GET')
+
+    def test_explicit_post_method(self):
+        calls = self._run_main(['POST', 'https://example.com/', '-d', 'a=1'])
+        self.assertEqual(calls[0]['method'], 'POST')
+        self.assertEqual(calls[0]['content'], 'a=1')
+
+    def test_custom_headers_forwarded(self):
+        calls = self._run_main(['-H', 'X-Custom: val', 'https://example.com/'])
+        self.assertIn('X-Custom', calls[0]['headers'])
+        self.assertEqual(calls[0]['headers']['X-Custom'], 'val')
+
+    def test_follow_redirects_flag(self):
+        self._run_main(['-L', 'https://example.com/'])
+        self.assertTrue(h3mod.CONFIG.follow_redirects)
+
+    def test_insecure_flag(self):
+        self._run_main(['-k', 'https://example.com/'])
+        self.assertTrue(h3mod.CONFIG.insecure)
+
+    def test_show_headers_flag(self):
+        self._run_main(['-i', 'https://example.com/'])
+        self.assertTrue(h3mod.CONFIG.show_headers)
+
+    def test_non_https_url_exits(self):
+        with patch('sys.argv', ['h3', 'http://example.com/']):
+            with self.assertRaises(SystemExit):
+                h3mod.main()
+
+    def test_get_with_data_exits(self):
+        with patch('sys.argv', ['h3', '-d', 'payload', 'https://example.com/']):
+            with self.assertRaises(SystemExit):
+                h3mod.main()
+
+    def test_proxy_url_parsed_and_forwarded(self):
+        calls = self._run_main(
+            ['--proxy', 'https://proxy.example.com:3128', 'https://example.com/'])
+        self.assertIsNotNone(calls[0]['proxy'])
+        self.assertEqual(calls[0]['proxy'].hostname, 'proxy.example.com')
+        self.assertEqual(calls[0]['proxy'].port, 3128)
+
+    def test_proxy_auth_forwarded(self):
+        calls = self._run_main(
+            ['--proxy', 'https://proxy.example.com:3128',
+             '--proxy-auth', 'user:pass',
+             'https://example.com/'])
+        self.assertEqual(calls[0]['proxy_auth'], 'user:pass')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds `--follow-redirects` / `-L` flag to automatically follow HTTP 3xx redirects, matching `curl -L` behaviour.

## Changes

### `src/h3/__init__.py`
- Add `MAX_REDIRECTS = 10` constant
- Add `urljoin` import for relative URL resolution
- Add `-L` / `--follow-redirects` argument to `parse_args()`
- Refactor `send_request()` into a redirect loop:
  - 301 / 302 / 303 → method downgraded to GET, body dropped
  - 307 / 308 → method and body preserved
  - Relative and absolute-path `Location` values resolved via `urljoin`
  - Non-`https://` redirect targets rejected with an error
  - Loop capped at `MAX_REDIRECTS` hops
- Add docstrings to module, `Http3ClientError`, `ProxyBadStatus`, `create_quic_configuration`, `send_request`

### Tests
- `tests/test_follow_redirects.py` — 13 tests: no-redirect default, single 301/302/307 follow, relative/absolute location resolution, POST→GET method downgrade, redirect loop guard
- `tests/test_send_request.py` — 29 tests: general `send_request` behaviour, `main()` arg-parsing, error paths, helper validation functions

### CI
- `.github/workflows/ci.yml` — flake8 lint + both test suites on Python 3.9 / 3.11 / 3.13
- `.flake8` — per-file ignores for pre-existing style in `src/`

### README
- Added `-L` example and a short redirect-following behaviour section